### PR TITLE
Added exception handling for user not found for /v1/track/get/

### DIFF
--- a/api/track.py
+++ b/api/track.py
@@ -9,11 +9,11 @@ from sqlalchemy import exc
 from sqlalchemy.sql.expression import select
 from flask_restful import Resource, request
 from geopy import Nominatim
-import re
 from extensions import db, ma, session
 from user import User
 from location import get_location, generate_unique_location_id
 from exceptions import APIException
+import re
 
 track = Blueprint('track', __name__, template_folder='templates')
 
@@ -51,6 +51,9 @@ class TrackManager(Resource):
             return jsonify({
                 "Message": "User id required"
             })
+        user = session.get(User, user_id)
+        if not user:
+            raise APIException("User does not exist", 404)
         schema = TrackSchema(many=True)
         statement = select(Track).where(Track.user_id == user_id)
         locations = session.execute(statement).scalars().all()

--- a/api/user.py
+++ b/api/user.py
@@ -12,9 +12,10 @@ from flask import Blueprint, jsonify, escape
 from sqlalchemy import exc
 from sqlalchemy.sql.expression import select
 from flask_restful import Resource, request
-import re
 from extensions import db, ma, session
 from exceptions import APIException
+import re
+
 user = Blueprint('user', __name__, template_folder='templates')
 
 class User(db.Model):


### PR DESCRIPTION
<!--- Release Notes
Your one liner release notes here
--->
### Release Notes
```
APIException is raised if provided user does not exist in the user table.
```

### Pull request type
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [ ] Other: 

### Pull request size
- [x] Tiny
- [ ] Small
- [ ] Medium
- [ ] Large

#### Describe the old behavior you are changing
- API didn't return any errors when an invalid user_id was provided to the `/v1/track/get` endpoint.

#### Describe the new behavior from this change
- API now returns 404 with an error message indicating user doesn't exist
